### PR TITLE
Discard stdout if DISCARD_STDOUT == true

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,7 @@ This is an image for running [Blackblaze B2 Command Line Tool](https://github.co
 ```
 docker run --rm -v /source/dir:/work -e ACCOUNT_ID=sampleId -e APPLICATION_KEY=sampleKey waldher/backblaze-b2 sync source b2://bucket/destination
 ```
+
+To discard stdout and only see error messages (useful in large sync operations),
+you can either redirect stdout to `/dev/null` or set a `DISCARD_STDOUT` environemnt variable
+to `true`.

--- a/entry.sh
+++ b/entry.sh
@@ -1,2 +1,7 @@
 #!/bin/sh
+
+#conditionally redirect stdout to /dev/null, so that only error messages are shown
+#https://github.com/Backblaze/B2_Command_Line_Tool/issues/396#issuecomment-482735417
+[ "$DISCARD_STDOUT" == "true" ] && exec 1>/dev/null
+
 /usr/bin/b2 authorize-account $ACCOUNT_ID $APPLICATION_KEY && /usr/bin/b2 $@


### PR DESCRIPTION
Based on [this comment](https://github.com/Backblaze/B2_Command_Line_Tool/issues/396#issuecomment-482735417), this adds the option to redirect stdout to `/dev/null` if the environment variable `DISCARD_STDOUT` is set to `true`. This is useful when running large syncs in situations where traditional redirection isn't possible.