### PR TITLE
upgrade to alpine 3.15 and py3-pip, fixing ssl issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.5
+FROM alpine:3.15
 
-RUN apk add --no-cache py2-pip
+RUN apk add --update --no-cache py3-pip
 
 RUN pip install b2
 


### PR DESCRIPTION
This changes resolves an ssl cert issue due (I believe) to stale root certs in the alpine 3.5 image.